### PR TITLE
[Refactor/#36] post entity와 dto에서 deadline, createdAt을 javascript의 Date처럼 변환

### DIFF
--- a/src/main/java/sku/moamoa/domain/comment/dto/CommentDto.java
+++ b/src/main/java/sku/moamoa/domain/comment/dto/CommentDto.java
@@ -1,10 +1,13 @@
 package sku.moamoa.domain.comment.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
 import lombok.*;
 import sku.moamoa.domain.user.dto.UserDto;
+
+import java.time.LocalDateTime;
 
 public class CommentDto {
     @Getter
@@ -20,9 +23,12 @@ public class CommentDto {
     @Getter
     @Builder
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
     public static class InfoResponse {
         private Long id;
         private String content;
         private UserDto.InfoResponse user;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/sku/moamoa/domain/comment/entity/Comment.java
+++ b/src/main/java/sku/moamoa/domain/comment/entity/Comment.java
@@ -3,6 +3,7 @@ package sku.moamoa.domain.comment.entity;
 import lombok.*;
 import sku.moamoa.domain.post.entity.Post;
 import sku.moamoa.domain.user.entity.User;
+import sku.moamoa.global.entity.BaseEntity;
 
 import javax.persistence.*;
 
@@ -10,7 +11,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "COMMENT")
-public class Comment {
+public class Comment extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.SEQUENCE)
     private Long id;
     private String content;

--- a/src/main/java/sku/moamoa/domain/post/dto/PostDto.java
+++ b/src/main/java/sku/moamoa/domain/post/dto/PostDto.java
@@ -1,5 +1,6 @@
 package sku.moamoa.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import io.swagger.annotations.ApiModel;
@@ -8,7 +9,7 @@ import sku.moamoa.domain.comment.dto.CommentDto;
 import sku.moamoa.domain.post.entity.JobPosition;
 import sku.moamoa.domain.user.dto.UserDto;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class PostDto {
@@ -22,7 +23,8 @@ public class PostDto {
         private String title;
         private String projectName;
         private String content;
-        private LocalDate deadline;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime deadline;
         private int headcount;
         private JobPosition jobPosition;
         private String[] techStackArr;
@@ -44,12 +46,15 @@ public class PostDto {
         public String title;
         private String projectName;
         private String content;
-        private LocalDate deadline;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime deadline;
         private int headcount;
         private JobPosition jobPosition;
         private UserDto.InfoResponse user;
         private List<TechStackDto.InfoResponse> techStackList;
         private List<CommentDto.InfoResponse> commentList;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime createdAt;
     }
     @Getter
     @Builder
@@ -61,11 +66,14 @@ public class PostDto {
         private String title;
         private String projectName;
         private String content;
-        private LocalDate deadline;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime deadline;
         private int headcount;
         private JobPosition jobPosition;
         private UserDto.InfoResponse user;
         private List<TechStackDto.InfoResponse> techStackList;
         private int commentCount;
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        private LocalDateTime createdAt;
     }
 }

--- a/src/main/java/sku/moamoa/domain/post/entity/Post.java
+++ b/src/main/java/sku/moamoa/domain/post/entity/Post.java
@@ -1,15 +1,18 @@
 package sku.moamoa.domain.post.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import sku.moamoa.domain.comment.entity.Comment;
 import sku.moamoa.domain.likeboard.entity.LikeBoard;
 import sku.moamoa.domain.user.entity.User;
+import sku.moamoa.global.entity.BaseEntity;
 
 import javax.persistence.*;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -17,7 +20,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "POSTS")
-public class Post {
+public class Post extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.SEQUENCE)
     @Column(name = "post_id")
     private Long id;
@@ -28,7 +31,9 @@ public class Post {
     @Column(name = "content")
     private String content;
     @Column(name = "deadline")
-    private LocalDate deadline;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime deadline;
     @Column(name = "headcount")
     private int headcount;
     @Enumerated(value = EnumType.STRING)
@@ -47,7 +52,7 @@ public class Post {
     private List<LikeBoard> likeBoardList = new ArrayList<>();
 
     @Builder
-    public Post(String title, String projectName, String content, LocalDate deadline, int headcount, JobPosition jobPosition, User user) {
+    public Post(String title, String projectName, String content, LocalDateTime deadline, int headcount, JobPosition jobPosition, User user) {
         this.title = title;
         this.projectName = projectName;
         this.content = content;

--- a/src/main/java/sku/moamoa/domain/post/mapper/PostMapper.java
+++ b/src/main/java/sku/moamoa/domain/post/mapper/PostMapper.java
@@ -78,6 +78,7 @@ public class PostMapper {
                 .id(comment.getId())
                 .content(comment.getContent())
                 .user(toPostInfoResDto(comment.getUser()))
+                .createdAt(comment.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/sku/moamoa/domain/post/mapper/PostMapper.java
+++ b/src/main/java/sku/moamoa/domain/post/mapper/PostMapper.java
@@ -65,6 +65,7 @@ public class PostMapper {
                 .user(toPostInfoResDto(post.getUser()))
                 .techStackList(toPostInfoResDtoList(post.getPostSearchList()))
                 .commentCount(post.getCommentList().size())
+                .createdAt(post.getCreatedAt())
                 .build();
     }
 
@@ -96,6 +97,7 @@ public class PostMapper {
                 .user(toPostInfoResDto(post.getUser()))
                 .techStackList(toPostInfoResDtoList(post.getPostSearchList()))
                 .commentList(toCommentInfoResDtoList(post.getCommentList()))
+                .createdAt(post.getCreatedAt())
                 .build();
     }
 
@@ -112,6 +114,7 @@ public class PostMapper {
                 .user(toPostInfoResDto(post.getUser()))
                 .techStackList(toPostInfoResDtoList(post.getPostSearchList()))
                 .commentCount(post.getCommentList().size())
+                .createdAt(post.getCreatedAt())
                 .build();
     }
 

--- a/src/main/java/sku/moamoa/domain/user/entity/User.java
+++ b/src/main/java/sku/moamoa/domain/user/entity/User.java
@@ -53,12 +53,3 @@ public class User extends BaseEntity {
     }
 
 }
-
-//{
-//        "email": "email@naver.com",
-//        "githubUrl": "github@githum.com",
-//        "imageUrl": "imgurl.com",
-//        "nickname": "송지민",
-//        "platform": "GITHUB",
-//        "portFolioUrl": "portfolio.com"
-//}


### PR DESCRIPTION
## 📢 기능 설명 
* deadline, post, comment의 create_at을 Date 형태로 변경
<img width="436" alt="image" src="https://github.com/Team13-MoaMoa/backend/assets/84628898/5b1d92ac-279c-483c-b9e3-9fe5bd993524">

<img width="305" alt="image" src="https://github.com/Team13-MoaMoa/backend/assets/84628898/675a7fe7-8ff1-45a9-b3af-cd6590e3ba16">

* deadline은 Date 형태로 입력 
<img width="311" alt="image" src="https://github.com/Team13-MoaMoa/backend/assets/84628898/61b11051-a5d5-4ad7-b7d8-89aaab4fdf80">


<br>

## 연결된 issue
close #36
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 